### PR TITLE
Ability to use a predefined label package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## git-labelmaker
-:flags: Create git labels from the command line using **`git-labelmaker`**! With it you can easily add or remove git-labels, making it easier for your project to adhere to a sane labelling scheme.
+:flags: Edit git labels from the command line using **`git-labelmaker`**! You can easily add or remove git-labels, making it easier for your project to adhere to a sane labelling scheme.
 
 ### Install
 

--- a/components/main-prompts.js
+++ b/components/main-prompts.js
@@ -5,6 +5,6 @@ module.exports = [
     type:     "list",
     name:     "main",
     message:  "Welcome to git-labelmaker!\nWhat would you like to do?",
-    choices:  [ "Add Labels", "Remove Labels", "Reset Token" ]
+    choices:  [ "Add Custom Labels", "Add Labels From Package", "Remove Labels", "Reset Token" ]
   }
 ];

--- a/index.js
+++ b/index.js
@@ -126,6 +126,7 @@ const configGitLabel = (repo, token) => {
         }
       };
 
+//    TODO: could be refactored to return the git.add as a promise..?
 const handleAddPrompts = (repo, token, newLabels) => {
         gitLabel.add( configGitLabel(repo, token), newLabels )
           .then(console.log)
@@ -166,7 +167,12 @@ const handleMainPrompts = (repo, ans) => {
                   }
                 }
               }], (ans) => {
-                console.log("packagePath === "+packagePath);
+                gitLabel.find( replaceAll( replaceAll( replaceAll(ans.path, '`', ""), '"', "" ), "'", "" ) )
+                  .then((newLabels)=>{
+                    return gitLabel.add( configGitLabel(repo, token), newLabels )
+                  })
+                  .then(console.log)
+                  .catch(console.warn);
               });
             }
             if ( ans.main.toLowerCase() === "remove labels" ){

--- a/index.js
+++ b/index.js
@@ -39,11 +39,11 @@ const setToken = (done) => {
         });
       };
 //  Recursivly asks if you want to add another new label, then calls a callback when youre all done
-const doAddPrompts = ( newLabels, done ) => {
+const doCustomLabelPrompts = ( newLabels, done ) => {
         iq.prompt( addPrompts, ( answers ) => {
           newLabels.push({ name: answers.labelName, color: answers.labelColor });
           if ( answers.addAnother ){
-            doAddPrompts( newLabels, done );
+            doCustomLabelPrompts( newLabels, done );
           }else{
             done( newLabels );
           }
@@ -91,7 +91,6 @@ const readGitConfig  = () => {
 //  Returns a config for gitLabel
 const configGitLabel = (repo, token) => {
         return {
-          //  TODO: HARDCODING THE API IN TSK TSK TSK...
           api:    'https://api.github.com',
           repo:   repo,
           token:  token
@@ -114,7 +113,17 @@ const handleMainPrompts = (repo, ans) => {
         fetchToken()
           .then((token)=>{
             if ( ans.main.toLowerCase() === "add labels" ){
-              doAddPrompts( [], handleAddPrompts.bind(null, repo, token));
+              // check if they want to add labels from a package
+              iq.prompt([{
+                name:    "addMethod",
+                type:    "list",
+                message: "Do you want to use a label package or create custom labels?",
+                choices: [ "Use a package", "Create custom labels" ]
+              }], (addMethodAns) => {
+                if ( addMethodAns.addMethod.toLowerCase() === "create custom labels" ) {
+                  doCustomLabelPrompts( [], handleAddPrompts.bind(null, repo, token));
+                }
+              });
             }
             if ( ans.main.toLowerCase() === "remove labels" ){
               doRemovePrompts(token, repo);


### PR DESCRIPTION
The user should be able to add [`git-label-packages`](https://github.com/jasonbellamy/git-label-packages) and [`git-label-faces`](https://github.com/himynameisdave/git-label-faces), as well as a local package file that the user has.

Resolves #13 
