### PR TITLE
Add .jshintrc with esnext option

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,3 @@
+{
+    "esnext": true
+}


### PR DESCRIPTION
This prevents warnings in atom/sublime about using ES6 features.
