### PR TITLE
Use the origin remote url

### DIFF
--- a/bin/modules/readGitConfig.js
+++ b/bin/modules/readGitConfig.js
@@ -4,14 +4,14 @@
  *    @return {Promise}  Promise that resolves with the contents of the git config file
  */
 "use strict";
-const fs = require("fs");
+const parse = require('parse-git-config');
 const err = require("../utils/errorGenerator")("GIT_CONFIG")("Unable to read git config file!")
 
 module.exports = () => {
   return new Promise((res, rej)=>{
-    fs.readFile( process.cwd()+'/.git/config', 'utf8', (e, data) => {
+    parse(function (e, config) {
       if (e) rej(err);
-      res( data );
-    })
+      res( config );
+    });
   });
 };

--- a/bin/modules/readRepo.js
+++ b/bin/modules/readRepo.js
@@ -7,12 +7,10 @@
 "use strict";
 const gitUrl = require("github-url-from-git");
 
-module.exports = ( rawConfig ) => {
-  //  Break the config file contents into an array of newlines
-  let urlLine = rawConfig.split("\n").filter( (item) => {
-    //  returns only the line with "url = " on it
-    return item.indexOf("url = ") > -1;
-  })[0].split("url = ")[1];// gets everything on the url line following "url = "
-  let repoParts = gitUrl(urlLine).split("/");// gives us an array of each part of
+module.exports = ( config ) => {
+  // Retrieve the url of the origin remote
+  // Some repo can have multiple origin
+  const url = config['remote "origin"']['url'];
+  const repoParts = gitUrl(url).split("/");// gives us an array of each part of
   return repoParts[repoParts.length-2] + "/" + repoParts[repoParts.length-1];
 };

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "git-label": "^4.1.1",
     "github-url-from-git": "^1.4.0",
     "inquirer": "^0.11.1",
-    "octonode": "^0.7.4"
+    "octonode": "^0.7.4",
+    "parse-git-config": "^0.4.0"
   }
 }


### PR DESCRIPTION
### Overview
- Use the origin remote url instead of the first remote url. In some case the first remote url wasn't a github repo url.
