### PR TITLE
Fix absolute paths

### DIFF
--- a/bin/modules/validateAddPackages.js
+++ b/bin/modules/validateAddPackages.js
@@ -5,20 +5,22 @@
  */
 "use strict";
 const fs = require("fs");
+const path = require("path");
 const removeAllFromStr = require("../utils/removeAllFromStr");
 const isJsonString = require("../utils/isJsonString");
 
 //  Not using arrows bc it will mess up "this" context
-module.exports = function (path) {
+module.exports = function (jsonPath) {
   // Declare function as asynchronous, and save the done callback
   let done = this.async();
   try {
-    if (path.indexOf(".json") < 0) {
+    if (jsonPath.indexOf(".json") < 0) {
       done("Not a JSON file");
       return;
     }
-    let packagePath = path.indexOf("/") === 0 ? path.replace("/","") : path;
-    let fullPath = process.cwd() + "/" + removeAllFromStr( packagePath, [ "`", '"', "'" ] )
+    // Calculate the full path of the JSON file based upon the current working directory. Using
+    // path.resolve allows for absolute paths to be used also.
+    let fullPath = path.resolve(process.cwd(), jsonPath);
     fs.readFile(fullPath, (err, data) => {
       if (err){ done(err); return; }
       if (isJsonString(data)) {

--- a/package.json
+++ b/package.json
@@ -2,8 +2,9 @@
   "name": "git-labelmaker",
   "version": "0.8.0",
   "description": "Manage your GitHub labels from the command line! ",
-  "main": "index.js",
+  "main": "bin/index.js",
   "scripts": {
+    "start": "./bin/index.js",
     "test": "echo No tests"
   },
   "repository": {
@@ -31,7 +32,7 @@
   },
   "homepage": "https://github.com/himynameisdave/git-labelmaker#readme",
   "dependencies": {
-    "buttercup": "0.17.0",
+    "buttercup": "~0.24.0",
     "git-label": "^4.1.1",
     "github-url-from-git": "^1.4.0",
     "inquirer": "^0.11.1",


### PR DESCRIPTION
Using absolute paths to the JSON packages was broken - this has been fixed using `path.resolve()`.

buttercup was also upgraded to the latest stable version.
