### PR TITLE
Add ability to set global packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules/
 *.bcup
+*.git-label-maker-config

--- a/bin/modules/validateAddPackages.js
+++ b/bin/modules/validateAddPackages.js
@@ -13,6 +13,8 @@ const isJsonString = require("../utils/isJsonString");
 module.exports = function (jsonPath) {
   // Declare function as asynchronous, and save the done callback
   let done = this.async();
+  // this is clunky, but this way we can just use a default
+  if (jsonPath === "") done(true);
   try {
     if (jsonPath.indexOf(".json") < 0) {
       done("Not a JSON file");

--- a/bin/prompts/mainMenu.js
+++ b/bin/prompts/mainMenu.js
@@ -7,6 +7,6 @@ module.exports = [
     type:     "list",
     name:     "main",
     message:  "Welcome to git-labelmaker!\nWhat would you like to do?",
-    choices:  [ "Add Custom Labels", "Add Labels From Package", "Create a Package From Labels", "Remove Labels", "Remove All Labels", "Reset Token", "Quit" ]
+    choices:  [ "Add Custom Labels", "Add Labels From Package", "Add Global Package", "Create a Package From Labels", "Remove Labels", "Remove All Labels", "Reset Token", "Quit" ]
   }
 ];

--- a/bin/utils/banners.js
+++ b/bin/utils/banners.js
@@ -14,6 +14,7 @@ module.exports = {
   welcome:             printBanner("    Welcome to git-labelmaker    "),
   addCustom:           printBanner("       Adding Custom Labels      "),
   addFromPackage:      printBanner("    Adding Labels From Package   "),
+  addGlobalPackage:    printBanner("       Add Global Package        "),
   createPkgFromLabels: printBanner("   Creating Package From Labels  "),
   removeLabels:        printBanner("         Removing Labels         "),
   resetToken:          printBanner("         Resetting Token         "),


### PR DESCRIPTION
This PR:
- Allows for a very crude form of setting a global package

Some questions:
- Should it be a specific format? i.e. would json make sense?
- Should the user be allowed to set multiple globals?
- What's the most logical way to use globals? Right now, I just have them as defaults if the user doesn't enter anything. But to me, that doesn't feel very intuitive at all.

Sorry if this PR is a bit crude, I just wanted to actually get started with it. Obviously, it'd be awesome if I could suggestions on improving it!