### PR TITLE
Recognize multiple remotes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules/
 *.bcup
+*.DS_Store

--- a/bin/index.js
+++ b/bin/index.js
@@ -35,10 +35,17 @@ const convertRGBToHex      = require("./modules/convertRGBToHex"),
 const gitLabelmaker = (token) => {
   Promise.all([ isGitRepo(), readGitConfig(), fetchToken(token) ])
     .then(( values )=>{
-      let _repo = readRepo(values[1]);
-      let _token = values[2];
-      banner.welcome();
-      iq.prompt( prompts.mainMenu, handleMainPrompts.bind(null, _repo, _token));
+      //  TODO: this is a bit callback-hellish
+      readRepo(values[1])
+        .then(_repo => {
+          let _token = values[2];
+          banner.welcome();
+          iq.prompt( prompts.mainMenu, handleMainPrompts.bind(null, _repo, _token));
+        })
+        .catch(e => {
+          console.error(e);
+          process.exit(1);
+        })
     })
     .catch((e)=>{
       switch (e.id) {

--- a/bin/modules/getParsedGitUrl.js
+++ b/bin/modules/getParsedGitUrl.js
@@ -1,0 +1,12 @@
+const gitUrl = require('github-url-from-git');
+
+module.exports = (config, remote, error) => {
+  const url = config[remote]['url'];
+  const parsedGitUrl = gitUrl(url);
+  const rootGithubUrl = 'https://github.com/';
+  //  Note: this is github specific
+  if (!parsedGitUrl && parsedGitUrl.indexOf(rootGithubUrl) === -1) return error();
+  parsedGitUrl
+        .split(rootGithubUrl) // -> ['', 'user/repo']
+        .reduce((a,b) => b.length ? b : a)
+};

--- a/bin/modules/readRepo.js
+++ b/bin/modules/readRepo.js
@@ -6,20 +6,55 @@
  */
 'use strict';
 const gitUrl = require('github-url-from-git');
+const prompt = require('./prompt.js');
+const askWhichRemotePrompt = require('../prompts/askWhichRemote.js');
 const err = require('../utils/errorGenerator')('READ_REPO')('Could not read git repo from your .git/ directory!')
 
-module.exports = ( config ) => {
-  const throwReadRepoError = () => {
-    console.error(`Error:\n    Code: ${err.id}\n    Message: ${err.message}`);
-    process.exit(1);
-  };
-  if (!config || !config['remote "origin"'] || !config['remote "origin"']['url']) return throwReadRepoError();
-  // Retrieve the url of the origin remote
-  // Some repo can have multiple origin
-  const url = config['remote "origin"']['url'];
-  const parsedGitUrl = gitUrl(url);
-  //  Note: this is github specific
-  if (!parsedGitUrl && parsedGitUrl.indexOf('https://github.com/') === -1) return throwReadRepoError();
-  return parsedGitUrl.split('https://github.com/') // -> ['', 'user/repo']
-                     .reduce((a,b) => b.length ? b : a); // gets the second item in array
+
+//  TODO: this could be broken off into an error-throwing module
+const throwReadRepoError = () => {
+  console.error(`Error:\n    Code: ${err.id}\n    Message: ${err.message}`);
+  process.exit(1);
+};
+//  TODO: Break these off too
+const hasMultipleRemotes = (config) => Object.keys(config).filter(key => key.indexOf('remote') > -1);
+const hasRemoteUrl = (config, remote) => remote && config[remote] && config[remote]['url'];
+
+module.exports = (config) => {
+
+  return new Promise((res, rej) => {
+    const remotes = hasMultipleRemotes(config);
+    if (!config || !remotes.length) return throwReadRepoError();
+
+    if (remotes.length > 1) {
+        prompt(askWhichRemotePrompt(remotes))
+            .then(({ remote }) => {
+                //  TODO: DRY, this could be broken off
+                const url = config[remote]['url'];
+                const parsedGitUrl = gitUrl(url);
+                //  Note: this is github specific
+                if (!parsedGitUrl && parsedGitUrl.indexOf('https://github.com/') === -1) return throwReadRepoError();
+                res(parsedGitUrl
+                      .split('https://github.com/') // -> ['', 'user/repo']
+                      .reduce((a,b) => b.length ? b : a) // gets the second item in array
+                );
+            })
+            .catch(e => {
+              throwReadRepoError(e);
+              rej(e); // TODO: redundant because throwReadRepoError exits
+            });
+    } else {
+      if (!hasRemoteUrl(config, remotes[0])) return throwReadRepoError();
+      // Retrieve the url of the origin remote
+      // Some repo can have multiple origin
+      const url = config[remotes[0]]['url'];
+      const parsedGitUrl = gitUrl(url);
+      //  Note: this is github specific
+      if (!parsedGitUrl && parsedGitUrl.indexOf('https://github.com/') === -1) return throwReadRepoError();
+      res(parsedGitUrl
+            .split('https://github.com/') // -> ['', 'user/repo']
+            .reduce((a,b) => b.length ? b : a) // gets the second item in array
+      );
+    }
+  });
 };

--- a/bin/modules/readRepo.js
+++ b/bin/modules/readRepo.js
@@ -5,7 +5,7 @@
  *    @return {String}  repo
  */
 'use strict';
-const gitUrl = require('github-url-from-git');
+const getParsedGitUrl = require('./getParsedGitUrl.js');
 const prompt = require('./prompt.js');
 const askWhichRemotePrompt = require('../prompts/askWhichRemote.js');
 const err = require('../utils/errorGenerator')('READ_REPO')('Could not read git repo from your .git/ directory!')
@@ -18,43 +18,25 @@ const throwReadRepoError = () => {
 };
 //  TODO: Break these off too
 const hasMultipleRemotes = (config) => Object.keys(config).filter(key => key.indexOf('remote') > -1);
+
 const hasRemoteUrl = (config, remote) => remote && config[remote] && config[remote]['url'];
 
-module.exports = (config) => {
 
-  return new Promise((res, rej) => {
-    const remotes = hasMultipleRemotes(config);
-    if (!config || !remotes.length) return throwReadRepoError();
+module.exports = (config) => new Promise((res, rej) => {
+  const remotes = hasMultipleRemotes(config);
+  if (!config || !remotes.length) return throwReadRepoError();
 
-    if (remotes.length > 1) {
-        prompt(askWhichRemotePrompt(remotes))
-            .then(({ remote }) => {
-                //  TODO: DRY, this could be broken off
-                const url = config[remote]['url'];
-                const parsedGitUrl = gitUrl(url);
-                //  Note: this is github specific
-                if (!parsedGitUrl && parsedGitUrl.indexOf('https://github.com/') === -1) return throwReadRepoError();
-                res(parsedGitUrl
-                      .split('https://github.com/') // -> ['', 'user/repo']
-                      .reduce((a,b) => b.length ? b : a) // gets the second item in array
-                );
-            })
-            .catch(e => {
-              throwReadRepoError(e);
-              rej(e); // TODO: redundant because throwReadRepoError exits
-            });
-    } else {
-      if (!hasRemoteUrl(config, remotes[0])) return throwReadRepoError();
-      // Retrieve the url of the origin remote
-      // Some repo can have multiple origin
-      const url = config[remotes[0]]['url'];
-      const parsedGitUrl = gitUrl(url);
-      //  Note: this is github specific
-      if (!parsedGitUrl && parsedGitUrl.indexOf('https://github.com/') === -1) return throwReadRepoError();
-      res(parsedGitUrl
-            .split('https://github.com/') // -> ['', 'user/repo']
-            .reduce((a,b) => b.length ? b : a) // gets the second item in array
-      );
-    }
-  });
-};
+  if (remotes.length > 1) {
+      prompt(askWhichRemotePrompt(remotes))
+          .then(({ remote }) => {
+              res(getParsedGitUrl(config, remote, throwReadRepoError));
+          })
+          .catch(e => {
+            throwReadRepoError(e);
+            rej(e); // TODO: redundant because throwReadRepoError exits
+          });
+  } else {
+    if (!hasRemoteUrl(config, remotes[0])) return throwReadRepoError();
+    res(getParsedGitUrl(config, remotes[0], throwReadRepoError));
+  }
+});

--- a/bin/prompts/askWhichRemote.js
+++ b/bin/prompts/askWhichRemote.js
@@ -1,0 +1,10 @@
+/**
+ *    The "are you sure you wanna delete these labels" prompt
+ */
+`use strict`;
+module.exports = (remotes) => [{
+  name:     `remote`,
+  type:     `list`,
+  message:  `Looks like this repository has multiple remotes.\nWhich one would you like to use?`,
+  choices: remotes
+}];


### PR DESCRIPTION
A common open source workflow includes having an `origin` remote for my fork and an `upstream` fork for the primary project. I found, to use this tool, I have to rename my upstream to origin for it to work. 

I'm good with either updating documentation to include that note or adding additional logic to ask which remote is the right one. Your call 👍 

```
intelsdi-x/snap # git remote rename origin upstream
intelsdi-x/snap # git remote
mjbrender
upstream
intelsdi-x/snap # git-labelmaker
? You have a saved token.
Would you like to unlock & use this token, or create a new one? Use Saved Token
? What is your master password?
TypeError: Cannot read property 'url' of undefined
    at module.exports (/usr/local/lib/node_modules/git-labelmaker/bin/modules/readRepo.js:13:40)
    at Promise.all.then (/usr/local/lib/node_modules/git-labelmaker/bin/index.js:38:19)
 ✘ intelsdi-x/snap # git remote rename upstream origin
intelsdi-x/snap # git-labelmaker
? You have a saved token.
Would you like to unlock & use this token, or create a new one? Use Saved Token
? What is your master password?
=======================================
]|[                                 ]|[
]|[    Welcome to git-labelmaker    ]|[
]|[                                 ]|[
=======================================

? Welcome to git-labelmaker!
What would you like to do? Quit
=======================================
]|[                                 ]|[
]|[            See Ya!              ]|[
]|[                                 ]|[
=======================================
```
