### PR TITLE
30 labels limit

### DIFF
--- a/bin/modules/requestLabels.js
+++ b/bin/modules/requestLabels.js
@@ -8,11 +8,11 @@
 "use strict";
 const octonode = require("octonode");
 
-module.exports = ( repo, token ) => {
+module.exports = (repo, token) => {
   return new Promise((res, rej)=>{
-    octonode.client(token).get('/repos/'+repo+'/labels', (e, status, body) => {
-      if (e) rej(e);
-      res(body);
+    octonode.client(token).get('/repos/'+repo+'/labels', { per_page: 100 }, (e, status, body, headers) => {
+      if (e) return rej(e);
+      return res(body);
     });
   });
 };


### PR DESCRIPTION
If I'm not mistaken, Github paginates results for labels to 30 items by default (https://developer.github.com/v3/#pagination ?).
I happen to have more than 30 labels, so when I create a package from labels, it only takes the 30 first labels.

I'll do the rest by hand, but it'll be cool if the labelmaker was able to pull all the labels.