### PR TITLE
fix: update config git label to current api endpoint

### DIFF
--- a/bin/utils/config-git-label.js
+++ b/bin/utils/config-git-label.js
@@ -7,7 +7,7 @@
 
 
 module.exports = (repo, token) => ({
-    api:    'https://api.github.com',
+    api:    'https://api.github.com/repos',
     repo,
     token,
 });


### PR DESCRIPTION
Github changed his endpoints so the project didn't work correctly so this updated was needed